### PR TITLE
Added support for PostgresSQL

### DIFF
--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -64,7 +64,8 @@ func insertObjSet(db *gorm.DB, objects []interface{}, excludeColumns ...string) 
 		// Append variables
 		variables := make([]string, 0, attrSize)
 		for _, key := range sortedKeys(objAttrs) {
-			variables = append(variables, scope.AddToVars(objAttrs[key]))
+			scope.AddToVars(objAttrs[key])
+			variables = append(variables, "?")
 		}
 
 		valueQuery := "(" + strings.Join(variables, ", ") + ")"


### PR DESCRIPTION
Instead of using number placeholders such as `$1`, `$2`, `$3`, `$4`, …, I’m replaced them with `?` which works just fine with Postgres.

https://github.com/t-tiger/gorm-bulk-insert/issues/1