### PR TITLE
Add NowFunc in utils

### DIFF
--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -3,10 +3,10 @@ package gormbulk
 import (
 	"errors"
 	"fmt"
-	"github.com/jinzhu/gorm"
 	"reflect"
 	"strings"
-	"time"
+
+	"github.com/jinzhu/gorm"
 )
 
 // Insert multiple records at once
@@ -99,7 +99,7 @@ func extractMapValue(value interface{}, excludeColumns []string) (map[string]int
 		if !containString(excludeColumns, field.Struct.Name) && field.StructField.Relationship == nil && !hasForeignKey &&
 			!field.IsIgnored && !(field.DBName == "id" && field.IsPrimaryKey) {
 			if field.Struct.Name == "CreatedAt" || field.Struct.Name == "UpdatedAt" {
-				attrs[field.DBName] = time.Now()
+				attrs[field.DBName] = NowFunc()
 			} else if field.StructField.HasDefaultValue && field.IsBlank {
 				// If default value presents and field is empty, assign a default value
 				if val, ok := field.TagSettingsGet("DEFAULT"); ok {

--- a/utils.go
+++ b/utils.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-var NowFunc = func() time.Time {
+var NowFunc = func() interface{} {
 	return time.Now()
 }
 

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,13 @@
 package gormbulk
 
-import "sort"
+import (
+	"sort"
+	"time"
+)
+
+var NowFunc = func() time.Time {
+	return time.Now()
+}
 
 // Separate objects into several size
 func splitObjects(objArr []interface{}, size int) [][]interface{} {


### PR DESCRIPTION
I want to set unixtime to `created_at` and `deleted_at`.
In this commit, Add definition `NowFunc` in utils. If you want to change values of `created_at` and `deleted_at`, change function implementation in `gormbulk`
```
gormbulk.NowFunc = func() interface{} {
	return time.Now().Unix()
}
err := gormbulk.BulkInsert(infra.MySQL(), insertRecords, 3000)
```
