### PR TITLE
Correct module url in go.mod after repository name change

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/t-tiger/gormbulk
+module github.com/t-tiger/gorm-bulk-insert
 
 go 1.12
 


### PR DESCRIPTION
Change to correct the error bellow:

![go-module-error](https://user-images.githubusercontent.com/36285126/69016082-ac9ec300-0979-11ea-9f41-6c4f56ec38cd.jpg)

[Why this error occur](https://git.liushun.help/liushun/golang/commit/0da58d076a98a0fa027ea547b2a1c35147fd6e6e)
