### PR TITLE
Exclude columns which is primary key with empty value

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,19 +36,6 @@ Basically, inserting struct values are automatically chosen. However if you want
 
 In the above pattern `Name` and `Email` fields are excluded.
 
-### AUTO INCREMENT
-
-If auto_increment attribute is assigned to the primary key, make sure to set `gorm:"AUTO_INCREMENT"` tag in model struct.
-
-```go
-type fakeTable struct {
-	ID        int `gorm:"AUTO_INCREMENT"` 
-	Name      string
-}
-```
-
-This is necessary to exclude the auto_increment column from insertion and be numbered by database. The reason for this requirement is that if all primary keys are excluded, only surrogate key like auto_increment can be inserted and natural key cannot at all.
-
 ### Feature
 
 - Just pass a slice of struct as using gorm normally, records will be created.

--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -103,7 +103,7 @@ func extractMapValue(value interface{}, excludeColumns []string) (map[string]int
 		_, hasForeignKey := field.TagSettingsGet("FOREIGNKEY")
 
 		if !containString(excludeColumns, field.Struct.Name) && field.StructField.Relationship == nil && !hasForeignKey &&
-			!field.IsIgnored && !fieldIsAutoIncrement(field) {
+			!field.IsIgnored && !fieldIsAutoIncrement(field) && !fieldIsPrimaryAndBlank(field) {
 			if (field.Struct.Name == "CreatedAt" || field.Struct.Name == "UpdatedAt") && field.IsBlank {
 				attrs[field.DBName] = time.Now()
 			} else if field.StructField.HasDefaultValue && field.IsBlank {
@@ -126,4 +126,8 @@ func fieldIsAutoIncrement(field *gorm.Field) bool {
 		return strings.ToLower(value) != "false"
 	}
 	return false
+}
+
+func fieldIsPrimaryAndBlank(field *gorm.Field) bool {
+	return field.IsPrimaryKey && field.IsBlank
 }

--- a/bulk_insert_test.go
+++ b/bulk_insert_test.go
@@ -104,3 +104,27 @@ func Test_fieldIsAutoIncrement(t *testing.T) {
 		}
 	}
 }
+
+func Test_fieldIsPrimaryAndBlank(t *testing.T) {
+	type notPrimaryTable struct {
+		Dummy int
+	}
+	type primaryKeyTable struct {
+		ID int `gorm:"column:id;primary_key"`
+	}
+
+	cases := []struct {
+		Value    interface{}
+		Expected bool
+	}{
+		{notPrimaryTable{Dummy: 0}, false},
+		{notPrimaryTable{Dummy: 1}, false},
+		{primaryKeyTable{ID: 0}, true},
+		{primaryKeyTable{ID: 1}, false},
+	}
+	for _, c := range cases {
+		for _, field := range (&gorm.Scope{Value: c.Value}).Fields() {
+			assert.Equal(t, fieldIsPrimaryAndBlank(field), c.Expected)
+		}
+	}
+}


### PR DESCRIPTION
This PR is based on the issue #19.

Due to the commit [`eab1a9e`](https://github.com/t-tiger/gorm-bulk-insert/commit/eab1a9e08caf114df18894dee2233a550000c914), setting the AUTO_INCREMENT tag was obliged, but it is opposed to the default behavior of `gorm.Model`.

On the other hand, before that, there was a problem that natural keys that are not surrogate_key like auto_increment were also excluded from insertion.

Therefore, I need modification to solve both problems simultaneously, and this PR is a correction to deal with it. Detailed background can be found in this comment.
https://github.com/t-tiger/gorm-bulk-insert/issues/19#issuecomment-559149465

Solving the problem by excluding the column which is primary key with empty value from the insertion.

This is not completely logical implementation, but in normal use cases, the expected behavior is guaranteed. Therefore, I made this modification.