### PR TITLE
Fixed bulkinsert swallowing error from exec

### DIFF
--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -82,7 +82,8 @@ func insertObjSet(db *gorm.DB, objects []interface{}, excludeColumns ...string) 
 		strings.Join(placeholders, ", "),
 	))
 
-	return db.Exec(mainScope.SQL, mainScope.SQLVars...).Error
+	db = db.Exec(mainScope.SQL, mainScope.SQLVars...)
+	return db.Error
 }
 
 // Obtain columns and values required for insert from interface


### PR DESCRIPTION
I found that the error from `db.Exec` is swallowed. This PR will fix the issue and surface the error up the call stack.