### PR TITLE
Support gorm's insert_option for bulk upsert

### DIFF
--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -78,7 +78,11 @@ func insertObjSet(db *gorm.DB, objects []interface{}, excludeColumns ...string) 
 
 	insertOption := ""
 	if val, ok := db.Get("gorm:insert_option"); ok {
-		insertOption = val.(string)
+		strVal, ok := val.(string)
+		if !ok {
+			return errors.New("gorm:insert_option should be a string")
+		}
+		insertOption = strVal
 	}
 
 	mainScope.Raw(fmt.Sprintf("INSERT INTO %s (%s) VALUES %s %s",

--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -76,10 +76,16 @@ func insertObjSet(db *gorm.DB, objects []interface{}, excludeColumns ...string) 
 		mainScope.SQLVars = append(mainScope.SQLVars, scope.SQLVars...)
 	}
 
-	mainScope.Raw(fmt.Sprintf("INSERT INTO %s (%s) VALUES %s",
+	insertOption := ""
+	if val, ok := db.Get("gorm:insert_option"); ok {
+		insertOption = val.(string)
+	}
+
+	mainScope.Raw(fmt.Sprintf("INSERT INTO %s (%s) VALUES %s %s",
 		mainScope.QuotedTableName(),
 		strings.Join(dbColumns, ", "),
 		strings.Join(placeholders, ", "),
+		insertOption,
 	))
 
 	return db.Exec(mainScope.SQL, mainScope.SQLVars...).Error


### PR DESCRIPTION
This is a PR to support `gorm:insert_option` for bulk upsert, as requested in https://github.com/t-tiger/gorm-bulk-insert/issues/6. We can set the insert option with
```go
db = db.Set("gorm:insert_option", "ON CONFLICT ... DO UPDATE SET ...")
gormbulk.BulkInsert(db, ......)
```
It's consistent with [how insert_option is specified in gorm](http://gorm.io/docs/create.html#Extra-Creating-option).
This way we won't add new parameters to `BulkInsert()` so that backward compatibility is ensured.