### PR TITLE
ignoreError field added for unique fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ func main() {
 		)
 	}
 
-	err := gormbulk.BulkInsert(db, insertRecords, 3000)
+	err := gormbulk.BulkInsert(db, insertRecords, true, 3000)
 	if err != nil {
 		// do something
 	}
 
 	// columns you want to exclude from Insert, specify as an argument
-	err = gormbulk.BulkInsert(db, insertRecords, 3000, "Email")
+	err = gormbulk.BulkInsert(db, insertRecords, true, 3000, "Email")
         if err != nil {
             // do something
         }


### PR DESCRIPTION
If we use unique field for a struct, Exec function gives an error: "pq: duplicate key value violates unique constraint". Because of this error, it won't create batch if there is a same value for unique field which was already created. 

With using **ON CONFLICT DO NOTHING** we can ignore the error and creates the items in given batch.

Reference: https://www.postgresql.org/docs/9.5/sql-insert.html