### PR TITLE
Modify interface and implementation of BulkInsertWithAssigningIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,12 @@ func main() {
 	}
 
 	// Fetch returning values
-	dbForReturning := db.Set("gorm:insert_option", "RETURNING id, name, created_at")
 	var returned []struct {
 		ID        int
 		Name	  string
 		CreatedAt time.Time
 	}
-	err = gormbulk.BulkInsertWithReturningValues(dbForReturning, insertRecords, &returned, 3000)
+	err = gormbulk.BulkInsertWithReturningValues(db, insertRecords, &returned, 3000)
 	if err != nil {
 		// do something
 	}

--- a/README.md
+++ b/README.md
@@ -50,62 +50,64 @@ In the above pattern `Name` and `Email` fields are excluded.
 package main
 
 import (
-	"fmt"
-	"log"
-	"time"
+  "fmt"
+  "log"
+  "time"
 
-	"github.com/jinzhu/gorm"
-	_ "github.com/jinzhu/gorm/dialects/mysql"
-	gormbulk "github.com/t-tiger/gorm-bulk-insert/v2"
+  "github.com/jinzhu/gorm"
+  _ "github.com/jinzhu/gorm/dialects/mysql"
+  gormbulk "github.com/t-tiger/gorm-bulk-insert/v2"
 )
 
 type fakeTable struct {
-	ID        int `gorm:"AUTO_INCREMENT"`
-	Name      string
-	Email     string
-	CreatedAt time.Time
-	UpdatedAt time.Time
+  ID        int `gorm:"AUTO_INCREMENT"`
+  Name      string
+  Email     string
+  CreatedAt time.Time
+  UpdatedAt time.Time
 }
 
 func main() {
-	db, err := gorm.Open("mysql", "mydb")
-	if err != nil {
-		log.Fatal(err)
-	}
+  db, err := gorm.Open("mysql", "mydb")
+  if err != nil {
+    log.Fatal(err)
+  }
 
-	var insertRecords []interface{}
-	for i := 0; i < 10; i++ {
-		insertRecords = append(insertRecords,
-			fakeTable{
-				Name:  fmt.Sprintf("name%d", i),
-				Email: fmt.Sprintf("test%d@test.com", i),
-				// you don't need to set CreatedAt, UpdatedAt
-			},
-		)
-	}
+  var insertRecords []interface{}
+  for i := 0; i < 10; i++ {
+    insertRecords = append(insertRecords,
+      fakeTable{
+        Name:  fmt.Sprintf("name%d", i),
+        Email: fmt.Sprintf("test%d@test.com", i),
+        // you don't need to set CreatedAt, UpdatedAt
+      },
+    )
+  }
 
-	err = gormbulk.BulkInsert(db, insertRecords, 3000)
-	if err != nil {
-		// do something
-	}
+  err = gormbulk.BulkInsert(db, insertRecords, 3000)
+  if err != nil {
+    // do something
+  }
 
-	// Columns you want to exclude from Insert, specify as an argument
-	err = gormbulk.BulkInsert(db, insertRecords, 3000, "Email")
-	if err != nil {
-		// do something
-	}
-	
-	// Fetch returning values 
-	dbForReturning := db.Set("gorm:insert_option", "RETURNING id, name, created_at")
-	var returned []struct{
-      ID        int
-      Name      string
-      CreatedAt time.Time
-    }
-    err = gormbulk.BulkInsertWithReturningValues(dbForReturning, insertRecords, &returned, 3000)
-	if err != nil {
-		// do something
-    }
+  // Columns you want to exclude from Insert, specify as an argument
+  err = gormbulk.BulkInsert(db, insertRecords, 3000, "Email")
+  if err != nil {
+    // do something
+  }
+
+  // Fetch returning values
+  dbForReturning := db.Set("gorm:insert_option", "RETURNING id, name, created_at")
+  var returned []struct {
+    ID        int
+    Name      string
+    CreatedAt time.Time
+  }
+  err = gormbulk.BulkInsertWithReturningValues(dbForReturning, insertRecords, &returned, 3000)
+  if err != nil {
+    // do something
+  }
+  // Values of `returned` will be as follows
+  // {{ID: 1, Name: "name0", CreatedAt: 2021-10-31 16:21:48.019947 +0000 UTC}, ...}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ import (
 
 type fakeTable struct {
 	ID        int `gorm:"AUTO_INCREMENT"`
-	Name	  string
-	Email	  string
+	Name      string
+	Email     string
 	CreatedAt time.Time
 	UpdatedAt time.Time
 }
@@ -106,7 +106,7 @@ func main() {
 	if err != nil {
 		// do something
 	}
-	// Values of `returned` will be as follows
+	// Values of `returned` will be like this
 	// {{ID: 1, Name: "name0", CreatedAt: 2021-10-31 16:21:48.019947 +0000 UTC}, ...}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -96,17 +96,22 @@ func main() {
 	}
 
 	// Fetch returning values
-	var returned []struct {
+	var returnedVals []struct {
 		ID        int
 		Name	  string
 		CreatedAt time.Time
 	}
-	err = gormbulk.BulkInsertWithReturningValues(db, insertRecords, &returned, 3000)
+	err = gormbulk.BulkInsertWithReturningValues(db, insertRecords, &returnedVals, 3000)
 	if err != nil {
 		// do something
 	}
-	// Values of `returned` will be like this
-	// {{ID: 1, Name: "name0", CreatedAt: 2021-10-31 16:21:48.019947 +0000 UTC}, ...}
+	
+	// Fetch returned IDs
+	var returnedIDs []int
+	err = gormbulk.BulkInsertWithReturningIDs(db, insertRecords, &returnedIDs, 3000)
+	if err != nil {
+		// do something
+	}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,64 +50,64 @@ In the above pattern `Name` and `Email` fields are excluded.
 package main
 
 import (
-  "fmt"
-  "log"
-  "time"
+	"fmt"
+	"log"
+	"time"
 
-  "github.com/jinzhu/gorm"
-  _ "github.com/jinzhu/gorm/dialects/mysql"
-  gormbulk "github.com/t-tiger/gorm-bulk-insert/v2"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/mysql"
+	gormbulk "github.com/t-tiger/gorm-bulk-insert/v2"
 )
 
 type fakeTable struct {
-  ID        int `gorm:"AUTO_INCREMENT"`
-  Name      string
-  Email     string
-  CreatedAt time.Time
-  UpdatedAt time.Time
+	ID        int `gorm:"AUTO_INCREMENT"`
+	Name	  string
+	Email	  string
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 func main() {
-  db, err := gorm.Open("mysql", "mydb")
-  if err != nil {
-    log.Fatal(err)
-  }
+	db, err := gorm.Open("mysql", "mydb")
+	if err != nil {
+		log.Fatal(err)
+	}
 
-  var insertRecords []interface{}
-  for i := 0; i < 10; i++ {
-    insertRecords = append(insertRecords,
-      fakeTable{
-        Name:  fmt.Sprintf("name%d", i),
-        Email: fmt.Sprintf("test%d@test.com", i),
-        // you don't need to set CreatedAt, UpdatedAt
-      },
-    )
-  }
+	var insertRecords []interface{}
+	for i := 0; i < 10; i++ {
+		insertRecords = append(insertRecords,
+			fakeTable{
+				Name:  fmt.Sprintf("name%d", i),
+				Email: fmt.Sprintf("test%d@test.com", i),
+				// you don't need to set CreatedAt, UpdatedAt
+			},
+		)
+	}
 
-  err = gormbulk.BulkInsert(db, insertRecords, 3000)
-  if err != nil {
-    // do something
-  }
+	err = gormbulk.BulkInsert(db, insertRecords, 3000)
+	if err != nil {
+		// do something
+	}
 
-  // Columns you want to exclude from Insert, specify as an argument
-  err = gormbulk.BulkInsert(db, insertRecords, 3000, "Email")
-  if err != nil {
-    // do something
-  }
+	// Columns you want to exclude from Insert, specify as an argument
+	err = gormbulk.BulkInsert(db, insertRecords, 3000, "Email")
+	if err != nil {
+		// do something
+	}
 
-  // Fetch returning values
-  dbForReturning := db.Set("gorm:insert_option", "RETURNING id, name, created_at")
-  var returned []struct {
-    ID        int
-    Name      string
-    CreatedAt time.Time
-  }
-  err = gormbulk.BulkInsertWithReturningValues(dbForReturning, insertRecords, &returned, 3000)
-  if err != nil {
-    // do something
-  }
-  // Values of `returned` will be as follows
-  // {{ID: 1, Name: "name0", CreatedAt: 2021-10-31 16:21:48.019947 +0000 UTC}, ...}
+	// Fetch returning values
+	dbForReturning := db.Set("gorm:insert_option", "RETURNING id, name, created_at")
+	var returned []struct {
+		ID        int
+		Name	  string
+		CreatedAt time.Time
+	}
+	err = gormbulk.BulkInsertWithReturningValues(dbForReturning, insertRecords, &returned, 3000)
+	if err != nil {
+		// do something
+	}
+	// Values of `returned` will be as follows
+	// {{ID: 1, Name: "name0", CreatedAt: 2021-10-31 16:21:48.019947 +0000 UTC}, ...}
 }
 ```
 

--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -34,8 +34,9 @@ func BulkInsert(db *gorm.DB, objects []interface{}, chunkSize int, excludeColumn
 }
 
 // BulkInsertWithReturningValues executes the query to insert multiple records at once.
-// This will scan the returned value into `dstValues`.
-// It's necessary to set "gorm:insert_option" to execute "returning" query.
+// This will scan the returned values into `returnedVals`.
+//
+// [db] must be set with "gorm:insert_option" to execute RETURNING clause. e.g. db.Set("gorm:insert_option", "RETURNING id")
 //
 // [objects] must be a slice of struct.
 //

--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -39,7 +39,7 @@ func BulkInsert(db *gorm.DB, objects []interface{}, chunkSize int, excludeColumn
 //
 // [objects] must be a slice of struct.
 //
-// [dstValues] must be a point to a slice of struct. Struct properties must correspond to returning results.
+// [returnedVals] must be a point to a slice of struct. Values returned from `RETURNING` clause will be assigned.
 //
 // [chunkSize] is a number of variables embedded in query. To prevent the error which occurs embedding a large number of variables at once
 // and exceeds the limit of prepared statement. Larger size normally leads to better performance, in most cases 2000 to 3000 is reasonable.

--- a/bulk_insert.go
+++ b/bulk_insert.go
@@ -53,7 +53,6 @@ func BulkInsertWithReturningValues(db *gorm.DB, objects []interface{}, returnedV
 	}
 
 	refDst := reflect.Indirect(reflect.ValueOf(returnedVals))
-	typ = refDst.Type()
 
 	// Split records with specified size not to exceed Database parameter limit
 	for _, objSet := range splitObjects(objects, chunkSize) {
@@ -61,7 +60,7 @@ func BulkInsertWithReturningValues(db *gorm.DB, objects []interface{}, returnedV
 		if err != nil {
 			return err
 		}
-		scanned := reflect.New(typ)
+		scanned := reflect.New(refDst.Type())
 		if err := db.Scan(scanned.Interface()).Error; err != nil {
 			return err
 		}

--- a/bulk_insert_test.go
+++ b/bulk_insert_test.go
@@ -85,9 +85,9 @@ func TestBulkInsertWithReturningValues_InvalidTypeOfReturnedVals(t *testing.T) {
 	tests := []struct {
 		name string
 		vals interface{}
-	} {
-		{name: "not a pointer", vals: []struct{Name string}{{Name: "1"}}},
-		{name: "element is not a slice", vals: &struct{Name string}{Name: "1"}},
+	}{
+		{name: "not a pointer", vals: []struct{ Name string }{{Name: "1"}}},
+		{name: "element is not a slice", vals: &struct{ Name string }{Name: "1"}},
 		{name: "slice element is not a struct", vals: &[]string{"1"}},
 	}
 	for _, tt := range tests {
@@ -211,6 +211,30 @@ func Test_fieldIsAutoIncrement(t *testing.T) {
 	for _, c := range cases {
 		for _, field := range (&gorm.Scope{Value: c.Value}).Fields() {
 			assert.Equal(t, fieldIsAutoIncrement(field), c.Expected)
+		}
+	}
+}
+
+func Test_fieldIsPrimaryAndBlank(t *testing.T) {
+	type notPrimaryTable struct {
+		Dummy int
+	}
+	type primaryKeyTable struct {
+		ID int `gorm:"column:id;primary_key"`
+	}
+
+	cases := []struct {
+		Value    interface{}
+		Expected bool
+	}{
+		{notPrimaryTable{Dummy: 0}, false},
+		{notPrimaryTable{Dummy: 1}, false},
+		{primaryKeyTable{ID: 0}, true},
+		{primaryKeyTable{ID: 1}, false},
+	}
+	for _, c := range cases {
+		for _, field := range (&gorm.Scope{Value: c.Value}).Fields() {
+			assert.Equal(t, fieldIsPrimaryAndBlank(field), c.Expected)
 		}
 	}
 }

--- a/bulk_insert_test.go
+++ b/bulk_insert_test.go
@@ -63,7 +63,6 @@ func TestBulkInsertWithReturningValues(t *testing.T) {
 		},
 	}
 
-	gdb = gdb.Set("gorm_insert_option", "RETURNING id, ThisIsCamelCase, regular_column")
 	err = BulkInsertWithReturningValues(gdb, obj, &returnedVals, 1000)
 	require.NoError(t, err)
 
@@ -171,7 +170,7 @@ func Test_insertObject(t *testing.T) {
 		sqlmock.NewResult(1, 1),
 	)
 
-	_, err = insertObjSet(gdb, []interface{}{
+	err = insertObjSet(gdb, []interface{}{
 		Table{
 			RegularColumn: "first regular",
 			Custom:        "first custom",


### PR DESCRIPTION
This PR is a follow-up of #50.

## Method only accepts a slice of struct for returning values

Previous PR accepts both slice of PK and slice of struct, but I feel it should be consistent and natural to just accept a slice of struct. Although the initial motivation was returning the created IDs, DB can return the multiple specified columns, so I think it would be better not to stick to returning PK as a library.

## Modify README

Change the example using `BulkInsertWithReturningValues`.